### PR TITLE
refactor: moderniza sección de rutinas

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -191,3 +191,8 @@ form div {
 .crop-area img { max-width:100%; max-height:100%; }
 .crop-actions { display:flex; justify-content:space-between; padding-top:8px; }
 .crop-actions button { background:none; border:0; color:var(--accent); font-size:16px; }
+.routines { min-height:100vh; padding:16px 16px 92px; background:var(--bg); color:var(--text); }
+.routine-form { min-height:100vh; padding:16px 16px 92px; background:var(--bg); color:var(--text); }
+.stations-inputs { display:flex; flex-direction:column; gap:6px; }
+.stations-inputs input { padding:10px 12px; border-radius:8px; border:1px solid var(--border); background:var(--card); color:var(--text); }
+.add-station { margin-top:8px; background:var(--accent); color:#001018; font-weight:800; border:0; padding:8px 12px; border-radius:8px; }

--- a/views/routines/index.pug
+++ b/views/routines/index.pug
@@ -1,12 +1,45 @@
 extends ../layout
 
 block content
-  h2 Rutinas
-  a(href='/routines/new') Crear rutina
-  if routines.length
-    ul
-      each routine in routines
-        li
-          a(href=`/routines/${routine.id}/start`) #{routine.name}
-  else
-    p No hay rutinas registradas.
+  .routines
+    .header
+      .left
+        h1 Mis rutinas
+      .right
+        a.add-disc(href="/routines/new" aria-label="Agregar rutina")
+          i.fa-solid.fa-plus
+    if routines.length
+      .grid
+        each r in routines
+          .card
+            .top
+              .meta #{r.stations.length} estaciones
+              a.edit(href=`/routines/${r.id}/edit` aria-label="Editar")
+                i.fa-solid.fa-pencil
+            .main
+              .info
+                h3= r.name
+            if r.stations && r.stations.length
+              .stations
+                each d in r.stations
+                  .badge #{d} m
+            a.btn-primary(href=`/routines/${r.id}/start?mode=total`)
+              i.fa-solid.fa-play
+              |  Iniciar
+    else
+      p No tienes rutinas todavía.
+    .bottom-nav
+      a.nav-item(class=activeTab==='home' ? 'active' : '', href="/")
+        i.fa-solid.fa-house
+        span Inicio
+      a.nav-item(class=activeTab==='discs' ? 'active' : '', href="/discs")
+        i.fa-solid.fa-compact-disc
+        span Discos
+      a.play(href="/session" aria-label="Iniciar sesión")
+        i.fa-solid.fa-bullseye
+      a.nav-item(class=activeTab==='routines' ? 'active' : '', href="/routines")
+        i.fa-solid.fa-list-check
+        span Rutinas
+      a.nav-item(class=activeTab==='you' ? 'active' : '', href="/you")
+        i.fa-solid.fa-user
+        span Tú

--- a/views/routines/new.pug
+++ b/views/routines/new.pug
@@ -1,13 +1,55 @@
 extends ../layout
 
 block content
-  h2 Nueva rutina
-  form(action='/routines/new' method='post')
-    div
-      label(for='name') Nombre:
-      input(type='text' name='name' id='name' required)
-    div
-      label(for='distances') Distancias de estaciones (separadas por coma en metros):
-      input(type='text' name='distances' id='distances' placeholder='5,7,10')
-    div
-      button(type='submit') Guardar
+  .routine-form
+    .header.form-header
+      a.close(href="/routines" aria-label="Cerrar")
+        i.fa-solid.fa-xmark
+      if routine
+        h1 Editar rutina
+      else
+        h1 Agregar rutina
+    form(action=routine ? `/routines/${routine.id}/edit` : '/routines/new' method='post')
+      .group
+        label(for='name') Nombre
+        input#name(type='text' name='name' required value=routine ? routine.name : '')
+      .group
+        label Distancias de estaciones (m)
+        .stations-inputs#stationsContainer
+          if routine && routine.stations.length
+            each d in routine.stations
+              input(type='number' name='stations' value=d min='0')
+          else
+            input(type='number' name='stations' min='0')
+        button.add-station(type='button' id='addStation') Añadir estación
+      .group
+        button.btn.btn-primary(type='submit') Guardar
+    .bottom-nav
+      a.nav-item(class=activeTab==='home' ? 'active' : '', href="/")
+        i.fa-solid.fa-house
+        span Inicio
+      a.nav-item(class=activeTab==='discs' ? 'active' : '', href="/discs")
+        i.fa-solid.fa-compact-disc
+        span Discos
+      a.play(href="/session" aria-label="Iniciar sesión")
+        i.fa-solid.fa-bullseye
+      a.nav-item(class=activeTab==='routines' ? 'active' : '', href="/routines")
+        i.fa-solid.fa-list-check
+        span Rutinas
+      a.nav-item(class=activeTab==='you' ? 'active' : '', href="/you")
+        i.fa-solid.fa-user
+        span Tú
+  script.
+    (function(){
+      const btn=document.getElementById('addStation');
+      const container=document.getElementById('stationsContainer');
+      if(btn && container){
+        btn.addEventListener('click',()=>{
+          const input=document.createElement('input');
+          input.type='number';
+          input.name='stations';
+          input.min='0';
+          container.appendChild(input);
+        });
+      }
+    })();

--- a/views/routines/result.pug
+++ b/views/routines/result.pug
@@ -1,7 +1,26 @@
 extends ../layout
 
 block content
-  h2 Resultados guardados
-  p ¿Deseas repetir la rutina?
-  a(href=`/routines/${routine.id}/start`) Repetir
-  a(href='/') Salir
+  .routine-form
+    .header.form-header
+      a.close(href="/routines" aria-label="Cerrar")
+        i.fa-solid.fa-xmark
+      h1 Resultados guardados
+    p ¿Deseas repetir la rutina?
+    a.btn.btn-primary(href=`/routines/${routine.id}/start?mode=total`) Repetir
+    a.btn.btn-primary(href='/') Salir
+    .bottom-nav
+      a.nav-item(class=activeTab==='home' ? 'active' : '', href="/")
+        i.fa-solid.fa-house
+        span Inicio
+      a.nav-item(class=activeTab==='discs' ? 'active' : '', href="/discs")
+        i.fa-solid.fa-compact-disc
+        span Discos
+      a.play(href="/session" aria-label="Iniciar sesión")
+        i.fa-solid.fa-bullseye
+      a.nav-item(class=activeTab==='routines' ? 'active' : '', href="/routines")
+        i.fa-solid.fa-list-check
+        span Rutinas
+      a.nav-item(class=activeTab==='you' ? 'active' : '', href="/you")
+        i.fa-solid.fa-user
+        span Tú

--- a/views/routines/start.pug
+++ b/views/routines/start.pug
@@ -1,45 +1,64 @@
 extends ../layout
 
 block content
-  h2 Iniciar rutina #{routine.name}
-  if !mode
-    form(action=`/routines/${routine.id}/start` method='get')
-      p Selecciona modalidad:
-      div
-        label
-          input(type='radio' name='mode' value='individual')
-          | Putts individuales
-      div
-        label
-          input(type='radio' name='mode' value='total')
-          | Putts totales
-      button(type='submit') Continuar
-  else if mode=='individual'
-    form(action=`/routines/${routine.id}/complete?mode=individual` method='post')
-      p Selecciona discos y registra resultados por círculo.
-      each disc in discs
+  .routine-form
+    .header.form-header
+      a.close(href="/routines" aria-label="Cerrar")
+        i.fa-solid.fa-xmark
+      h1 Iniciar rutina #{routine.name}
+    if !mode
+      form(action=`/routines/${routine.id}/start` method='get')
+        p Selecciona modalidad:
         div
           label
-            input(type='checkbox' name='discIds' value=disc.id)
-            | #{disc.brand} #{disc.model}
-          br
-          |  C1 intentos:
-          input(type='number' name=`attc1_${disc.id}` min='0' value='0')
-          |  C1 aciertos:
-          input(type='number' name=`hitc1_${disc.id}` min='0' value='0')
-          br
-          |  C2 intentos:
-          input(type='number' name=`attc2_${disc.id}` min='0' value='0')
-          |  C2 aciertos:
-          input(type='number' name=`hitc2_${disc.id}` min='0' value='0')
-      button(type='submit') Guardar resultados
-  else if mode=='total'
-    form(action=`/routines/${routine.id}/complete?mode=total` method='post')
-      each station, i in routine.stations
+            input(type='radio' name='mode' value='individual')
+            | Putts individuales
         div
-          label Estación #{i+1} (#{station} m)
-          |  Putts:
-          input(type='number' name=`attempts_${i}` min='0' value='0')
-          |  Aciertos:
-          input(type='number' name=`hits_${i}` min='0' value='0')
-      button(type='submit') Guardar resultados
+          label
+            input(type='radio' name='mode' value='total')
+            | Putts totales
+        button.btn.btn-primary(type='submit') Continuar
+    else if mode=='individual'
+      form(action=`/routines/${routine.id}/complete?mode=individual` method='post')
+        p Selecciona discos y registra resultados por círculo.
+        each disc in discs
+          div
+            label
+              input(type='checkbox' name='discIds' value=disc.id)
+              | #{disc.brand} #{disc.model}
+            br
+            |  C1 intentos:
+            input(type='number' name=`attc1_${disc.id}` min='0' value='0')
+            |  C1 aciertos:
+            input(type='number' name=`hitc1_${disc.id}` min='0' value='0')
+            br
+            |  C2 intentos:
+            input(type='number' name=`attc2_${disc.id}` min='0' value='0')
+            |  C2 aciertos:
+            input(type='number' name=`hitc2_${disc.id}` min='0' value='0')
+        button.btn.btn-primary(type='submit') Guardar resultados
+    else if mode=='total'
+      form(action=`/routines/${routine.id}/complete?mode=total` method='post')
+        each station, i in routine.stations
+          div
+            label Estación #{i+1} (#{station} m)
+            |  Putts:
+            input(type='number' name=`attempts_${i}` min='0' value='0')
+            |  Aciertos:
+            input(type='number' name=`hits_${i}` min='0' value='0')
+        button.btn.btn-primary(type='submit') Guardar resultados
+    .bottom-nav
+      a.nav-item(class=activeTab==='home' ? 'active' : '', href="/")
+        i.fa-solid.fa-house
+        span Inicio
+      a.nav-item(class=activeTab==='discs' ? 'active' : '', href="/discs")
+        i.fa-solid.fa-compact-disc
+        span Discos
+      a.play(href="/session" aria-label="Iniciar sesión")
+        i.fa-solid.fa-bullseye
+      a.nav-item(class=activeTab==='routines' ? 'active' : '', href="/routines")
+        i.fa-solid.fa-list-check
+        span Rutinas
+      a.nav-item(class=activeTab==='you' ? 'active' : '', href="/you")
+        i.fa-solid.fa-user
+        span Tú


### PR DESCRIPTION
## Summary
- Moderniza la sección de rutinas con tarjetas y navegación inferior
- Agrega formulario dinámico para crear/editar rutinas
- Habilita edición de rutinas desde el servidor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7675e84808322b0bec4289b802cfa